### PR TITLE
Proposed changes

### DIFF
--- a/src/DummyHandler/Handlers/FooEventHandler.cs
+++ b/src/DummyHandler/Handlers/FooEventHandler.cs
@@ -23,10 +23,9 @@ namespace DummyHandler.Handlers
                 };
 
                 i++;
-                Console.WriteLine($"Sending BarEvent with ID {barEvent.Id}");
                 await context.Publish(barEvent).ConfigureAwait(false);
-                Console.WriteLine($"Published BarEvent to send with ID {barEvent.Id}");
             }
+            Console.WriteLine($"Published 10 BarEvent events.");
         }
     }
 }

--- a/src/DummyHandler/Program.cs
+++ b/src/DummyHandler/Program.cs
@@ -19,14 +19,13 @@ namespace DummyHandler
             config.AuditProcessedMessagesTo("audit");
             config.LimitMessageProcessingConcurrencyTo(10);
 
-            // Cinfigure ASB
+            // Configure ASB
             var transport = config.UseTransport<AzureServiceBusTransport>();
-            transport.ConnectionString("");
-            transport.TopicName("master");
+            transport.ConnectionString(Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString"));
 
             var endpointInstance = await Endpoint.Start(config)
                 .ConfigureAwait(false);
-            
+
             Console.WriteLine("Press any key to exit");
             Console.ReadKey();
             await endpointInstance.Stop()

--- a/src/DummyHandler/Program.cs
+++ b/src/DummyHandler/Program.cs
@@ -22,6 +22,7 @@ namespace DummyHandler
             // Configure ASB
             var transport = config.UseTransport<AzureServiceBusTransport>();
             transport.ConnectionString(Environment.GetEnvironmentVariable("AzureServiceBus_ConnectionString"));
+            transport.PrefetchCount(2);
 
             var endpointInstance = await Endpoint.Start(config)
                 .ConfigureAwait(false);


### PR DESCRIPTION
- Simplify sender to perform quick send of a specific number of events to prep the receiver test
- Clean receiver handler to eliminate unnecessary console.writeline delayes
- Read connection string from an environment variable to eliminate copy/paste and accidental commits
- Reduce receiver `PrefetchCount` to two to eliminate potential of stale messages and still have a repro working